### PR TITLE
Fix bug in REACH reader

### DIFF
--- a/indra_reading/readers/reach/__init__.py
+++ b/indra_reading/readers/reach/__init__.py
@@ -128,16 +128,7 @@ class ReachReader(Reader):
                 continue
 
             # Look for things that are more like file names, rather than ids.
-            cid = content.get_id()
-            if isinstance(cid, str) and re.match('^\w*?\d+$', cid) is None:
-                new_id = 'FILE%06d' % i
-                i += 1
-                self.id_maps[new_id] = cid
-                content.change_id(new_id)
-                new_fpath = content.copy_to(self.input_dir)
-            else:
-                # Put the content in the appropriate directory.
-                new_fpath = content.copy_to(self.input_dir)
+            new_fpath = content.copy_to(self.input_dir)
             self.num_input += 1
             logger.debug('%s saved for reading by reach.'
                          % new_fpath)

--- a/indra_reading/readers/reach/__init__.py
+++ b/indra_reading/readers/reach/__init__.py
@@ -118,7 +118,6 @@ class ReachReader(Reader):
     def prep_input(self, content_iter):
         """Apply the readers to the content."""
         logger.info("Prepping input.")
-        i = 0
         for content in content_iter:
             # Check the quality of the text, and skip if there are any issues.
             quality_issue = self._check_content(content.get_text())
@@ -127,7 +126,6 @@ class ReachReader(Reader):
                                % (content.get_id(), quality_issue))
                 continue
 
-            # Look for things that are more like file names, rather than ids.
             new_fpath = content.copy_to(self.input_dir)
             self.num_input += 1
             logger.debug('%s saved for reading by reach.'


### PR DESCRIPTION
This PR removes a bug in the REACH Reader whereby it would rather arbitrarily change names of files to e.g. FILE00001.