### PR TITLE
Handle staggered submissions alongside multiple monitors

### DIFF
--- a/indra_reading/readers/sparser/__init__.py
+++ b/indra_reading/readers/sparser/__init__.py
@@ -43,7 +43,7 @@ class SparserReader(Reader):
         for content in content_iter:
             quality_issue = self._check_content(content.get_text())
             if quality_issue is not None:
-                logger.warning("Skipping %d due to: %s"
+                logger.warning("Skipping %s due to: %s"
                                % (content.get_id(), quality_issue))
                 continue
 

--- a/indra_reading/scripts/submit_reading_pipeline.py
+++ b/indra_reading/scripts/submit_reading_pipeline.py
@@ -782,6 +782,12 @@ def create_read_parser():
         type=int,
         help='Number of PMIDs to read for each AWS Batch job.'
     )
+    parent_read_parser.add_argument(
+        '--stagger',
+        default=0,
+        type=int,
+        help="Set the amount of time to wait between job submissions in secs."
+    )
     ''' Not currently supported.
     parent_read_parser.add_argument(
         '--num_tries',


### PR DESCRIPTION
This PR primarily reconciles two recent changes to reading: the ability to stagger submissions over time, and the ability to run multiple job monitors, each of which is observing a different queue. This PR also surfaces the stagger feature to the command line CLI.