### PR TITLE
Implement Eidos reader

### DIFF
--- a/indra_reading/readers/__init__.py
+++ b/indra_reading/readers/__init__.py
@@ -32,3 +32,8 @@ try:
     from .sparser import SparserReader
 except Exception as e:
     logger.warning(err_msg.format(reader="Sparser", err=str(e)))
+
+try:
+    from .eidos import EidosReader
+except Exception as e:
+    logger.warning(err_msg.format(reader="Eidos", err=str(e)))

--- a/indra_reading/readers/eidos/Dockerfile
+++ b/indra_reading/readers/eidos/Dockerfile
@@ -1,0 +1,3 @@
+FROM 292075781285.dkr.ecr.us-east-1.amazonaws.com/indra_db:latest
+ENV EIDOSPATH /sw/eidos-assembly-0.2.3-SNAPSHOT.jar
+ADD eidos-assembly-0.2.3-SNAPSHOT.jar $EIDOSPATH

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -86,5 +86,5 @@ class EidosReader(Reader):
 
     @staticmethod
     def get_processor(content):
-        return eidos.process_json(content)
+        return eidos.process_json_bio(content)
 

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -21,7 +21,7 @@ class EidosReader(Reader):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.num_input = 0
-        self.output_dir = get_dir(self.tmp_dir, 'input')
+        self.input_dir = get_dir(self.tmp_dir, 'input')
         self.output_dir = get_dir(self.tmp_dir, 'output')
 
     @classmethod

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -67,7 +67,10 @@ class EidosReader(Reader):
                 path.splitext(path.basename(json_file))[0])[0]
             logger.info('Content ID: %s' % content_id)
             with open(json_file, 'r') as fh:
-                content = json.load(fh)
+                try:
+                    content = json.load(fh)
+                except json.JSONDecodeError:
+                    content = None
             self.add_result(content_id, content)
         return self.results
 

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -26,8 +26,8 @@ class EidosReader(Reader):
 
     @classmethod
     def get_version(cls):
-        return re.match(r'eidos-assembly-(.+).jar',
-                        get_config('EIDOSPATH')).groups()[0]
+        jar_name = path.basename(get_config('EIDOSPATH'))
+        return re.match(r'eidos-assembly-(.+).jar', jar_name).groups()[0]
 
     def prep_input(self, content_iter):
         logger.info('Prepping input.')

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -5,11 +5,11 @@ import logging
 from os import path, remove, listdir
 from indra.sources import eidos
 from indra.config import get_config
-from indra_reading.readers.content import Content
 from indra.literature.pmc_client import extract_text
 from indra.sources.eidos.cli import extract_from_directory
-from indra_reading.readers.core import Reader, ReadingError
+from indra_reading.readers.core import Reader
 from indra_reading.readers.util import get_dir
+from indra_reading.readers.content import Content
 
 
 logger = logging.getLogger(__name__)
@@ -93,4 +93,3 @@ class EidosReader(Reader):
     @staticmethod
     def get_processor(content):
         return eidos.process_json_bio(content)
-

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -62,7 +62,10 @@ class EidosReader(Reader):
         """Get the output of a reading job as a list of filenames."""
         logger.info('Getting Eidos outputs.')
         for json_file in glob.glob(path.join(self.output_dir, '*.jsonld')):
-            content_id = path.basename(json_file)
+            # We do splitext to remove double extensions like .txt.jsonld
+            content_id = path.splitext(
+                path.splitext(path.basename(json_file))[0])[0]
+            logger.info('Content ID: %s' % content_id)
             with open(json_file, 'r') as fh:
                 content = json.load(fh)
             self.add_result(content_id, content)

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -1,0 +1,88 @@
+import glob
+import json
+import logging
+from os import path, remove, listdir
+from indra.sources import eidos
+from indra.config import get_config
+from indra_reading.readers.content import Content
+from indra.literature.pmc_client import extract_text
+from indra.sources.eidos.cli import extract_from_directory
+from indra_reading.readers.core import Reader, ReadingError
+from indra_reading.readers.util import get_dir
+
+
+logger = logging.getLogger(__name__)
+
+
+class EidosReader(Reader):
+    name = 'EIDOS'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_input = 0
+        self.output_dir = get_dir(self.tmp_dir, 'input')
+        self.output_dir = get_dir(self.tmp_dir, 'output')
+
+    @classmethod
+    def get_version(cls):
+        return get_config('EIDOS_VERSION')
+
+    def prep_input(self, content_iter):
+        logger.info('Prepping input.')
+        for content in content_iter:
+            # If it's an NXML, we get the raw text and save it as new content
+            if content.is_format('nxml'):
+                txt = extract_text(content.get_text())
+                content = \
+                    Content.from_string(str(content.get_id()),
+                                        'txt', txt)
+            quality_issue = self._check_content(content.get_text())
+            if quality_issue is not None:
+                logger.warning('Skipping %s due to: %s'
+                               % (content.get_id(), quality_issue))
+                continue
+
+            new_fpath = content.copy_to(self.input_dir)
+            self.num_input += 1
+            logger.debug('%s saved for reading by Eidos.' % new_fpath)
+        return
+
+    def clear_input(self):
+        """Remove all the input files (at the end of a reading)."""
+        for item in listdir(self.input_dir):
+            item_path = path.join(self.input_dir, item)
+            if path.isfile(item_path):
+                remove(item_path)
+                logger.debug('Removed input %s.' % item_path)
+        return
+
+    def get_output(self):
+        """Get the output of a reading job as a list of filenames."""
+        logger.info('Getting Eidos outputs.')
+        for json_file in glob.glob(path.join(self.output_dir, '*.jsonld')):
+            content_id = path.basename(json_file)
+            with open(json_file, 'r') as fh:
+                content = json.load(fh)
+            self.add_result(content_id, content)
+        return self.results
+
+    def _read(self, content_iter, verbose=False, log=False):
+        ret = []
+        self.prep_input(content_iter)
+
+        # Make sure there is something to read before we start up Reach.
+        if not self.num_input:
+            return ret
+
+        extract_from_directory(self.input_dir, self.output_dir)
+
+        # Get the output
+        ret = self.get_output()
+        self.clear_input()
+
+        return ret
+
+    @staticmethod
+    def get_processor(content):
+        return eidos.process_json(content)
+

--- a/indra_reading/readers/eidos/__init__.py
+++ b/indra_reading/readers/eidos/__init__.py
@@ -1,3 +1,4 @@
+import re
 import glob
 import json
 import logging
@@ -25,7 +26,8 @@ class EidosReader(Reader):
 
     @classmethod
     def get_version(cls):
-        return get_config('EIDOS_VERSION')
+        return re.match(r'eidos-assembly-(.+).jar',
+                        get_config('EIDOSPATH')).groups()[0]
 
     def prep_input(self, content_iter):
         logger.info('Prepping input.')
@@ -70,7 +72,7 @@ class EidosReader(Reader):
         ret = []
         self.prep_input(content_iter)
 
-        # Make sure there is something to read before we start up Reach.
+        # Make sure there is something to read before we start up Eidos.
         if not self.num_input:
             return ret
 

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -1,0 +1,19 @@
+version: 0.1
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR and getting Eidos JAR...
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION)
+      - aws s3 cp s3://bigmech/travis/eidos-assembly-0.2.3-SNAPSHOT.jar .
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR and getting Eidos JAR...
-      - $(aws ecr get-login --region $AWS_DEFAULT_REGION)
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - aws s3 cp s3://bigmech/travis/eidos-assembly-0.2.3-SNAPSHOT.jar .
   build:
     commands:


### PR DESCRIPTION
This PR implements an Eidos reader class which uses `indra.sources.eidos.cli` to run Eidos on a set of input files. I tested EidosReader locally on a folder with some text and nxml files and the results look good to me, though when running on large corpora, corner cases could definitely come up. The PR also implements a Dockerfile and buildspec.yml which builds the environment in which the EidosReader can operate. The build files are already on S3, the CodeBuild job set up, and the repository with an initial build is on ECR (indra_eidos_reading:latest). However, rebuilding the underlying Docker stack (indra and indra_db) would be required to propagate all necessary changes into indra_eidos_reading before putting it in production.