### PR TITLE
Add geonames resource to Eidos build

### DIFF
--- a/indra_reading/readers/eidos/Dockerfile
+++ b/indra_reading/readers/eidos/Dockerfile
@@ -5,3 +5,9 @@ RUN rm -r /sw/reach && \
     rm bionetgen.tar.gz && \
     rm -r BioNetGen*
 ADD eidos-assembly-0.2.3-SNAPSHOT.jar $EIDOSPATH
+# Create geonames resource to avoid runtime download
+RUN mkdir -p /sw/cache/geonames/index && \
+    wget -nv https://bigmech.s3.amazonaws.com/travis/geonames%2Bworedas.zip && \
+    mv geonames+woredas.zip /sw/cache/geonames/index && \
+    cd /sw/cache/geonames/index && \
+    unzip geonames+woredas.zip


### PR DESCRIPTION
This PR adds the geonames resource during the build to the Eidos docker to avoid having it downloaded during runtime (the download is usually quick but sometimes the server behind it times out). Tested locally to confirm it finds the index when reading within the container.