### PR TITLE
Update Reach version to 1.6.3

### DIFF
--- a/indra_reading/readers/reach/reach_conf_fmt.txt
+++ b/indra_reading/readers/reach/reach_conf_fmt.txt
@@ -1,50 +1,52 @@
 #
-# Configuration file for reach
+# Main Configuration file for Reach.
 #
 
 # Default top-level root directory for input and output files and subdirectories.
 # All other paths are based on this path but any or all can be changed individually:
 rootDir = {tmp_dir}
 
+# this is where the brat standoff and text files are dumped
+# if this directory does not exist it will be created
+bratDir = {tmp_dir}/brat
+
+# this is where the context files will be stored
+# if this directory does not exist it will be created
+contextDir = {tmp_dir}/context
+
+# this is where the output files containing the extracted mentions will be stored
+# if this directory does not exist it will be created
+outDir = {tmp_dir}/output
+
 # this is the directory that stores the raw nxml, .csv, and/or .tsv files
 # this directory *must* exist
 papersDir = {tmp_dir}/input
 
-# this is where the output files containing the extracted mentions will be stored
-# if this directory doesn't exist it will be created
-outDir = {tmp_dir}/output
-
-# the output formats for mentions:
-# "arizona" (column-based, one file per paper)
-# "cmu" (column-based, one file per paper)
-# "fries" (multiple JSON files per paper)
-# "serial-json" (JSON serialization of mentions data structures. LARGE output!)
-# "text" (non-JSON textual format)
-outputTypes = ["fries"]
-
-# which processor to use:
-# bionlp: the classic BioNLPProcessor, with the Stanford constituent parser; slower but better
-# fastbionlp: FastBioNLPProcessor, which uses the new NN Stanford dependency parser; faster but slightly worse performance
-proc = "bionlp"
-
-# whether or not assembly should be run
-withAssembly = false
-
-# this is where the context files will be stored
-# if this directory doesn't exist it will be created
-contextDir = {tmp_dir}/context
-
-# this is where the brat standoff and text files are dumped
-bratDir = {tmp_dir}/brat
-
-# verbose logging
-verbose = true
 
 # the encoding of input and output files
 encoding = "utf-8"
 
 # this is a list of sections that we should ignore
 ignoreSections = ["references", "materials", "materials|methods", "methods", "supplementary-material"]
+
+# the output formats for mentions:
+# "fries" (multiple JSON files per paper)
+# "serial-json" (JSON serialization of mentions data structures. LARGE output!)
+# "text" (non-JSON textual format)
+# "indexcard" (Index cards)
+# "assembly-tsv" (assembly output)
+# "arizona" (Arizona's custom tabular output for assembly)
+# "cmu" (CMU's custom tabular output for assembly)
+outputTypes = ["fries"]
+
+# number of simultaneous threads to use for parallelization
+threadLimit = {num_cores}
+
+# verbose logging
+verbose = true
+
+# whether or not assembly should be run
+withAssembly = false
 
 # context engine config
 contextEngine {{
@@ -54,7 +56,6 @@ contextEngine {{
   }}
 }}
 
-# Polarity engine config
 polarity {{
   engine = Hybrid //Hybrid//DeepLearning //Linguistic
   negCountThreshold = 1 // when lower than or equal to this value, use linguistic approach in hybrid method
@@ -80,6 +81,18 @@ experimentalRegulation {{
   keywords = /experimental_regulation_type_keywords.csv // This is a resource!
 }}
 
+# grounding configuration
+grounding: {{
+  # List of AdHoc grounding files to insert, in order, into the grounding search sequence.
+  # Each element of the list is a map of KB filename and optional meta info (not yet used):
+  #   example: {{ kb: "adhoc.tsv", source: "NMZ at CMU" }}
+  adHocFiles: [
+    {{ kb: "NER-Grounding-Override.tsv.gz", source: "MITRE/NMZ/BG feedback overrides" }}
+  ]
+
+  # flag to turn off the influence of species on grounding
+  overrideSpecies = true
+}}
 
 # logging configuration
 logging {{
@@ -95,37 +108,6 @@ restart {{
   # restart log is one filename per line list of input files already successfully processed
   logfile = {tmp_dir}/restart.log
 }}
-
-# grounding configuration
-grounding: {{
-  # List of AdHoc grounding files to insert, in order, into the grounding search sequence.
-  # Each element of the list is a map of KB filename and optional meta info (not yet used):
-  #   example: {{ kb: "adhoc.tsv", source: "NMZ at CMU" }}
-  adHocFiles: [
-    {{ kb: "NER-Grounding-Override.tsv.gz", source: "MITRE/NMZ/BG feedback overrides" }}
-  ]
-
-  # flag to turn off the influence of species on grounding
-  overrideSpecies = true
-}}
-
-# Akka-based Processor Client configuration:
-ProcessorCoreClient {{
-  server {{
-    // path to the processor core server
-    // path = "akka.tcp://proc-core-server@192.168.1.12:2552/user/proc-actor-pool"
-    path = "akka://procCoreServer/user/procActorPool"
-
-    // the actor system name string
-    systemName = "procCoreServer"
-  }}
-
-  // request timeout in seconds. default: 3 min because BioNLP is slow to start
-  askTimeout = 180
-}}
-
-# number of simultaneous threads to use for parallelization
-threadLimit = {num_cores}
 
 # ReadPapers
 ReadPapers.papersDir = src/test/resources/inputs/nxml/

--- a/indra_reading/readers/reach/reach_conf_fmt.txt
+++ b/indra_reading/readers/reach/reach_conf_fmt.txt
@@ -54,6 +54,33 @@ contextEngine {{
   }}
 }}
 
+# Polarity engine config
+polarity {{
+  engine = Hybrid //Hybrid//DeepLearning //Linguistic
+  negCountThreshold = 1 // when lower than or equal to this value, use linguistic approach in hybrid method
+  maskOption = tag //tag_name //name //tag
+  savedModel = SavedLSTM_WideBound_u // SavedLSTM // SavedLSTM_WideBound
+  w2i = /lstmPolarityW2i.txt // save the word to index dictionary of the lstm polarity classifier.
+  c2i = /lstmPolarityC2i.txt // save the character to index dictionoary of the lstm polarity classifier.
+  dynetMem =  2048 // number should be in MB, clipped to 3072 Mb by the classifier.
+
+
+  spreadsheetPath = /SentencesInfo_all_label_final_ExactRecur_ExpandBound_universal.txt
+  VOC_SIZE = 3671
+  WEM_DIMENSIONS = 100
+  CEM_DIMENSIONS = 30
+  NUM_LAYERS = 1
+  HIDDEN_SIZE = 30
+  MLP_HIDDEN_SIZE = 10
+  N_EPOCH = 3
+  //engine = Linguistic
+}}
+
+experimentalRegulation {{
+  keywords = /experimental_regulation_type_keywords.csv // This is a resource!
+}}
+
+
 # logging configuration
 logging {{
   # defines project-wide logging level


### PR DESCRIPTION
This PR goes along with https://github.com/indralab/indra_deps_docker/pull/8 and updates the Reach configuration format to match the corresponding original one in the current version of Reach as closely as possible.