### PR TITLE
Extend Reach configuration

### DIFF
--- a/indra_reading/readers/reach/__init__.py
+++ b/indra_reading/readers/reach/__init__.py
@@ -28,18 +28,28 @@ class ReachReader(Reader):
     def __init__(self, *args, **kwargs):
         self.exec_path, self.version = self._check_reach_env()
         super(ReachReader, self).__init__(*args, **kwargs)
-        conf_fmt_fname = path.join(path.dirname(__file__),
-                                   'reach_conf_fmt.txt')
+        # This is the main application configuration file
+        conf_fmt_fname = path.join(path.dirname(__file__), 'reach_conf_fmt.txt')
+        # This is the KB configuration file which has to be prepended
+        # to make a full working configuration file
+        kb_conf_fname = path.join(path.dirname(__file__), 'kb_conf.txt')
+        # Read in the KB config
+        with open(kb_conf_fname, 'r') as fh:
+            kb_conf = fh.read()
+
         self.conf_file_path = path.join(self.tmp_dir, 'indra.conf')
         with open(conf_fmt_fname, 'r') as fmt_file:
             fmt = fmt_file.read()
             log_level = 'INFO'
             # log_level = 'DEBUG' if logger.level == logging.DEBUG else 'INFO'
+            # Format the main config to our specific setting
+            conf_formatted = fmt.format(tmp_dir=self.tmp_dir,
+                                        num_cores=self.n_proc,
+                                        loglevel=log_level)
+            # Now prepend the KB config and write out to a file
+            full_conf = kb_conf + conf_formatted
             with open(self.conf_file_path, 'w') as f:
-                f.write(
-                    fmt.format(tmp_dir=self.tmp_dir, num_cores=self.n_proc,
-                               loglevel=log_level)
-                )
+                f.write(full_conf)
         self.output_dir = get_dir(self.tmp_dir, 'output')
         self.num_input = 0
         return

--- a/indra_reading/readers/reach/kb_conf.txt
+++ b/indra_reading/readers/reach/kb_conf.txt
@@ -1,0 +1,265 @@
+KnowledgeBasesPath = "org/clulab/reach/kb"
+
+KnowledgeBases
+    {
+        StaticBioProcess{
+            path = ${KnowledgeBasesPath}/bio_process.tsv
+            isAdHoc = true
+            labels = [BioProcess]
+            priority = 1
+        }
+
+        gendCellLocation{
+            path = ${KnowledgeBasesPath}/biopax-cellular_component.tsv
+            labels = [Cellular_component]
+            priority = 2
+        }
+
+
+
+        StaticCellLocation{
+            path = ${KnowledgeBasesPath}/GO-subcellular-locations.tsv
+
+            namespace = "go"
+            baseURI = "http://identifiers.org/go/"
+            resourceId = "MMIR:00000022"
+            priority = 3
+            labels = [Cellular_component]
+        }
+
+        StaticCellLocation2{
+            path = ${KnowledgeBasesPath}/uniprot-subcellular-locations.tsv
+
+            namespace = "uniprot"
+            baseURI = "http://identifiers.org/go/"
+            resourceId = "MMIR:00000005"
+            priority = 4
+            labels = [Cellular_component]
+        }
+
+
+        StaticProtein{
+            path = ${KnowledgeBasesPath}/uniprot-proteins-0_F.tsv
+
+            namespace = uniprot
+            baseURI = "http://identifiers.org/uniprot/"
+            resourceId = "MIR:00100164"
+            priority = 5
+            species = [Human, Homo sapiens]
+            hasSpeciesInfo = true
+            isProteinKB = true
+            labels = [Gene_or_gene_product]
+
+            keyTransforms = [DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        StaticProtein2{
+            path = ${KnowledgeBasesPath}/uniprot-proteins-G_P.tsv
+
+            namespace = uniprot
+            baseURI = "http://identifiers.org/uniprot/"
+            resourceId = "MIR:00100164"
+            priority = 6
+            isProteinKB = true
+            species = [Human, Homo sapiens]
+            labels = [Gene_or_gene_product]
+
+            keyTransforms = [DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        StaticProtein3{
+            path = ${KnowledgeBasesPath}/uniprot-proteins-Q_Z.tsv
+
+            namespace = uniprot
+            baseURI = "http://identifiers.org/uniprot/"
+            resourceId = "MIR:00100164"
+            priority = 7
+            hasSpeciesInfo = true
+            isProteinKB = true
+            species = [Human, Homo sapiens]
+            labels = [Gene_or_gene_product]
+
+            keyTransforms = [DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        StaticProteinFragment{
+            path = ${KnowledgeBasesPath}/protein-ontology-fragments.tsv
+
+            namespace = proonto
+            isProteinKB = true
+            labels = [Gene_or_gene_product]
+            species = [Human, Homo sapiens]
+            keyTransforms = [DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms]
+            priority = 8
+        }
+
+        gendProteinFamily{
+            path = ${KnowledgeBasesPath}/biopax-gene_or_gene_product.tsv
+            priority =9
+            labels = [Gene_or_gene_product]
+            isFamilyKB = true
+        }
+
+        StaticProteinFamily{
+            path = ${KnowledgeBasesPath}/PFAM-families.tsv
+
+            namespace = "pfam",
+            baseURI = "http://identifiers.org/pfam/",
+            resourceId = "MIR:00000028",
+            isFamilyKB = true
+            priority = 10
+            labels = [Family]
+
+            keyTransforms = [DefaultKeyTransforms, FamilyAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        StaticProteinFamily2{
+            path = ${KnowledgeBasesPath}/ProteinFamilies.tsv
+
+            namespace = "interpro",
+            baseURI = "http://identifiers.org/interpro/",
+            resourceId = "MIR:00000011",
+            hasSpeciesInfo = true,
+            isFamilyKB = true
+            priority = 11
+            species = [Human, Homo sapiens]
+            labels = [Family]
+
+            keyTransforms = [DefaultKeyTransforms, FamilyAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        StaticProteinFamilyOrComplex{
+            path = ${KnowledgeBasesPath}/famplex.tsv
+
+            namespace = fplx
+            baseURI = "http://identifiers.org/fplx/"
+            priority = 12
+            isFamilyKB = true
+            labels = [Family]
+        }
+        
+        gendChemical{
+            path = ${KnowledgeBasesPath}/biopax-simple_chemical.tsv
+            priority = 13
+            labels = [Simple_chemical]
+        }
+
+#         StaticMetabolite{
+#             path = "hmdb.tsv"
+#
+#            namespace = "hmdb"
+#             baseURI = "http://identifiers.org/hmdb/"
+#             resourceId = "MMIR:00000051"
+#             priority = 4
+#             labels = [Simple_chemical]
+#         }
+
+        StaticChemical{
+            path = ${KnowledgeBasesPath}/PubChem.tsv
+
+            namespace = "pubchem"
+            baseURI = "http://identifiers.org/pubchem.compound/"
+            resourceId = "MMIR:00000034"
+            priority = 14
+            labels = [Simple_chemical] #If missing labels, then BioEntity will be used as default
+        }
+
+        StaticDrug{
+            path = ${KnowledgeBasesPath}/hms-drugs.tsv
+
+            namespace = "pubchem"
+            baseURI = "http://identifiers.org/pubchem.compound/"
+            resourceId = "MMIR:00000034"
+            priority = 15
+            labels = [Simple_chemical] #If missing labels, then BioEntity will be used as default
+        }
+
+        StaticChemicalChebi{
+            path = ${KnowledgeBasesPath}/chebi.tsv
+
+            namespace = "chebi"
+            baseURI = "http://identifiers.org/chebi/"
+            resourceId = "MMIR:00100009"
+            priority = 16
+            labels = [Simple_chemical] #If missing labels, then BioEntity will be used as default
+        }
+
+
+        Interpro {
+            path = ${KnowledgeBasesPath}/InterPro-protein-domains.tsv
+            labels = [Site]
+            priority = 17
+        }
+
+        StaticDiseases{
+            path = ${KnowledgeBasesPath}/mesh-disease.tsv
+
+            namespace = mesh
+            baseURI = "http://identifiers.org/mesh/"
+            resourceId = "MIR:00000560"
+            priority = 18
+            labels = [Disease]
+        }
+
+        ContextCellLine{
+            path = ${KnowledgeBasesPath}/Cellosaurus.tsv
+
+            namespace = cellosaurus
+            hasSpeciesInfo = true
+            priority = 19
+            species = [Human, Homo sapiens]
+            labels = [CellLine]
+        }
+
+        ContextCellLine2{
+            path = ${KnowledgeBasesPath}/atcc.tsv
+
+            namespace = atcc
+            priority = 20
+            labels = [CellLine]
+        }
+
+        ContextCellType{
+            path = ${KnowledgeBasesPath}/CellOntology.tsv
+
+            namespace = cl
+            baseURI = "http://identifiers.org/cl/"
+            resourceId = "MIR:00000110"
+            priority = 21
+            labels = [CellType]
+        }
+
+        ContextOrgan{
+            path = ${KnowledgeBasesPath}/Uberon.tsv
+
+            namespace = uberon
+            baseURI = "http://identifiers.org/uberon/"
+            resourceId = "MIR:00000446"
+            priority = 22
+            labels = [Organ]
+            keyTransforms = [DefaultKeyTransforms, OrganAuxKeyTransforms, DefaultKeyTransforms]
+        }
+
+        ContextSpecies{
+            path = ${KnowledgeBasesPath}/Species.tsv
+
+            namespace = taxonomy
+            baseURI = "http://identifiers.org/taxonomy/"
+            resourceId = "MIR:00000006"
+            priority = 23
+            labels = [Species]
+        }
+
+        ContextTissueType{
+            path = ${KnowledgeBasesPath}/tissue-type.tsv
+
+            namespace = tissuelist
+            baseURI = "http://identifiers.org/tissuelist/"
+            resourceId = "MIR:00000360"
+            priority = 24
+            labels = [TissueType]
+        }
+
+
+    }
+

--- a/indra_reading/readers/reach/reach_conf_fmt.txt
+++ b/indra_reading/readers/reach/reach_conf_fmt.txt
@@ -48,7 +48,7 @@ verbose = true
 # whether or not assembly should be run
 withAssembly = false
 
-# context engine config
+# context engine configuration
 contextEngine {{
   type = Policy4
   params = {{
@@ -87,7 +87,7 @@ grounding: {{
   # Each element of the list is a map of KB filename and optional meta info (not yet used):
   #   example: {{ kb: "adhoc.tsv", source: "NMZ at CMU" }}
   adHocFiles: [
-    {{ kb: "NER-Grounding-Override.tsv.gz", source: "MITRE/NMZ/BG feedback overrides" }}
+    {{ kb: "NER-Grounding-Override.tsv", source: "MITRE/NMZ/BG feedback overrides" }}
   ]
 
   # flag to turn off the influence of species on grounding


### PR DESCRIPTION
This PR makes further changes to adapt to the latest Reach version, namely:
- The latest Reach prepends a KB configuration part to the main configuration during compile time, and this has to be passed in appropriately when using a custom external configuration file. This PR adds the KB config as a separate resource file here and does the prepending before writing out the custom config.
- The path to the overrides file is fixed in the main config.