### PR TITLE
Update Eidos Dockerization

### DIFF
--- a/indra_reading/readers/eidos/Dockerfile
+++ b/indra_reading/readers/eidos/Dockerfile
@@ -1,4 +1,5 @@
-FROM 292075781285.dkr.ecr.us-east-1.amazonaws.com/indra_db:latest
+ARG AWS_ACCOUNT_ID
+FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/indra_db:latest
 ENV EIDOSPATH /sw/eidos-assembly-0.2.3-SNAPSHOT.jar
 RUN rm -r /sw/reach && \
     rm -r /sw/sparser && \

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG indra_reading/readers/eidos
+      - docker build --build-arg AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID -t $IMAGE_REPO_NAME:$IMAGE_TAG indra_reading/readers/eidos
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -f indra_reading/readers/eidos/Dockerfile -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG indra_reading/readers/eidos
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR and getting Eidos JAR...
-      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
       - aws s3 cp s3://bigmech/travis/eidos-assembly-0.2.3-SNAPSHOT.jar .
   build:
     commands:

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker build -f indra_reading/readers/eidos/Dockerfile -t $IMAGE_REPO_NAME:$IMAGE_TAG .
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:

--- a/indra_reading/readers/eidos/buildspec.yml
+++ b/indra_reading/readers/eidos/buildspec.yml
@@ -5,7 +5,7 @@ phases:
     commands:
       - echo Logging in to Amazon ECR and getting Eidos JAR...
       - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
-      - aws s3 cp s3://bigmech/travis/eidos-assembly-0.2.3-SNAPSHOT.jar .
+      - aws s3 cp s3://bigmech/travis/eidos-assembly-0.2.3-SNAPSHOT.jar indra_reading/readers/eidos/
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
This PR updates the code in Eidos' Dockerfile:
- Parameterize AWS account ID for better portability
- Update ECR login due to changes in AWS CLI
- Update the build command to point to the Dockerfile location